### PR TITLE
A generic Must function

### DIFF
--- a/hash.go
+++ b/hash.go
@@ -12,10 +12,10 @@ import (
 
 // Well known namespace IDs and UUIDs
 var (
-	NameSpace_DNS  = MustParse("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
-	NameSpace_URL  = MustParse("6ba7b811-9dad-11d1-80b4-00c04fd430c8")
-	NameSpace_OID  = MustParse("6ba7b812-9dad-11d1-80b4-00c04fd430c8")
-	NameSpace_X500 = MustParse("6ba7b814-9dad-11d1-80b4-00c04fd430c8")
+	NameSpace_DNS  = Must(Parse("6ba7b810-9dad-11d1-80b4-00c04fd430c8"))
+	NameSpace_URL  = Must(Parse("6ba7b811-9dad-11d1-80b4-00c04fd430c8"))
+	NameSpace_OID  = Must(Parse("6ba7b812-9dad-11d1-80b4-00c04fd430c8"))
+	NameSpace_X500 = Must(Parse("6ba7b814-9dad-11d1-80b4-00c04fd430c8"))
 	NIL            UUID // empty UUID, all zeros
 )
 

--- a/json_test.go
+++ b/json_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-var testUUID = MustParse("f47ac10b-58cc-0372-8567-0e02b2c3d479")
+var testUUID = Must(Parse("f47ac10b-58cc-0372-8567-0e02b2c3d479"))
 
 func TestJSON(t *testing.T) {
 	type S struct {

--- a/seq_test.go
+++ b/seq_test.go
@@ -42,7 +42,7 @@ func TestClockSeqRace(t *testing.T) {
 				select {
 				case <-done:
 					return
-				case ch <- MustNewUUID():
+				case ch <- Must(NewUUID()):
 				}
 			}
 		}()

--- a/sql_test.go
+++ b/sql_test.go
@@ -15,7 +15,7 @@ func TestScan(t *testing.T) {
 	var invalidTest string = "f47ac10b-58cc-0372-8567-0e02b2c3d4"
 
 	byteTest := make([]byte, 16)
-	byteTestUUID := MustParse(stringTest)
+	byteTestUUID := Must(Parse(stringTest))
 	copy(byteTest, byteTestUUID[:])
 
 	// sunny day tests
@@ -94,7 +94,7 @@ func TestScan(t *testing.T) {
 
 func TestValue(t *testing.T) {
 	stringTest := "f47ac10b-58cc-0372-8567-0e02b2c3d479"
-	uuid := MustParse(stringTest)
+	uuid := Must(Parse(stringTest))
 	val, _ := uuid.Value()
 	if val != stringTest {
 		t.Error("Value() did not return expected string")

--- a/uuid.go
+++ b/uuid.go
@@ -77,12 +77,12 @@ func ParseBytes(b []byte) (UUID, error) {
 	return Parse(*(*string)(unsafe.Pointer(&b)))
 }
 
-func MustParse(s string) UUID {
-	u, err := Parse(s)
+// Must returns uuid if err is nil and panics otherwise.
+func Must(uuid UUID, err error) UUID {
 	if err != nil {
 		panic(err)
 	}
-	return u
+	return uuid
 }
 
 // String returns the string form of uuid, xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx

--- a/version1.go
+++ b/version1.go
@@ -42,13 +42,3 @@ func NewUUID() (UUID, error) {
 
 	return uuid, nil
 }
-
-// MustNewUUID returns the Verison 1 UUID from calling NewUUID, or panics
-// if NewUUID fails.
-func MustNewUUID() UUID {
-	uuid, err := NewUUID()
-	if err != nil {
-		panic(err)
-	}
-	return uuid
-}

--- a/version4.go
+++ b/version4.go
@@ -4,7 +4,17 @@
 
 package uuid
 
-// New returns a Random (Version 4) UUID or panics.
+import "io"
+
+// New is creates a new random UUID or panics.  New is equivalent to
+// the expression
+//
+//    uuid.Must(uuid.NewRandom())
+func New() UUID {
+	return Must(NewRandom())
+}
+
+// NewRandom returns a Random (Version 4) UUID or panics.
 //
 // The strength of the UUIDs is based on the strength of the crypto/rand
 // package.
@@ -16,10 +26,13 @@ package uuid
 //  means the probability is about 0.00000000006 (6 × 10−11),
 //  equivalent to the odds of creating a few tens of trillions of UUIDs in a
 //  year and having one duplicate.
-func New() UUID {
+func NewRandom() (UUID, error) {
 	var uuid UUID
-	randomBits([]byte(uuid[:]))
+	_, err := io.ReadFull(rander, uuid[:])
+	if err != nil {
+		return UUID{}, err
+	}
 	uuid[6] = (uuid[6] & 0x0f) | 0x40 // Version 4
 	uuid[8] = (uuid[8] & 0x3f) | 0x80 // Variant is 10
-	return uuid
+	return uuid, nil
 }

--- a/version4.go
+++ b/version4.go
@@ -30,7 +30,7 @@ func NewRandom() (UUID, error) {
 	var uuid UUID
 	_, err := io.ReadFull(rander, uuid[:])
 	if err != nil {
-		return UUID{}, err
+		return NIL, err
 	}
 	uuid[6] = (uuid[6] & 0x0f) | 0x40 // Version 4
 	uuid[8] = (uuid[8] & 0x3f) | 0x80 // Variant is 10


### PR DESCRIPTION
- The MustParse and MustNewUUID functions have been removed since they can be replaced simply using the new function.

```go
    uuid.Must(uuid.Parse(s))
    uuid.Must(uuid.NewUUID())
```

- Create NewRandom func consistent with other version constructors.The New function is kept for convenience and relies on the NewRandom function.

- This also fixes a spurious bug in the UnmarshalJSON method that prevented compiling the json.go file.