### PR TITLE
Misc godoc fixes

### DIFF
--- a/dce.go
+++ b/dce.go
@@ -61,7 +61,7 @@ func (uuid UUID) Domain() Domain {
 	return Domain(uuid[9])
 }
 
-// Id returns the id for a Version 2 UUID. Ids are only defined for Vrsion 2
+// Id returns the id for a Version 2 UUID. Ids are only defined for Version 2
 // UUIDs.
 func (uuid UUID) Id() uint32 {
 	return binary.BigEndian.Uint32(uuid[0:4])

--- a/marshal.go
+++ b/marshal.go
@@ -10,33 +10,33 @@ import (
 )
 
 // MarshalText implements encoding.TextMarshaler.
-func (u UUID) MarshalText() ([]byte, error) {
+func (uuid UUID) MarshalText() ([]byte, error) {
 	var js [36]byte
-	encodeHex(js[:], u)
+	encodeHex(js[:], uuid)
 	return js[:], nil
 }
 
 // UnmarshalText implements encoding.TextUnmarshaler.
-func (u *UUID) UnmarshalText(data []byte) error {
+func (uuid *UUID) UnmarshalText(data []byte) error {
 	// See comment in ParseBytes why we do this.
 	// id, err := ParseBytes(data)
         id, err := Parse(*(*string)(unsafe.Pointer(&data)))
 	if err == nil {
-		*u = id
+		*uuid = id
 	}
 	return err
 }
 
 // MarshalBinary implements encoding.BinaryMarshaler.
-func (u UUID) MarshalBinary() ([]byte, error) {
-	return u[:], nil
+func (uuid UUID) MarshalBinary() ([]byte, error) {
+	return uuid[:], nil
 }
 
 // UnmarshalBinary implements encoding.BinaryUnmarshaler.
-func (u *UUID) UnmarshalBinary(data []byte) error {
+func (uuid *UUID) UnmarshalBinary(data []byte) error {
 	if len(data) != 16 {
 		return fmt.Errorf("invalid UUID (got %d bytes)", len(data))
 	}
-	copy(u[:], data)
+	copy(uuid[:], data)
 	return nil
 }

--- a/uuid.go
+++ b/uuid.go
@@ -67,7 +67,7 @@ func Parse(s string) (UUID, error) {
 	return uuid, nil
 }
 
-// ParseBytes is like Parse, exect it parses a byte slice instead of a string.
+// ParseBytes is like Parse, except it parses a byte slice instead of a string.
 func ParseBytes(b []byte) (UUID, error) {
 	// Parsing a string is actually faster than parsing a byte slice as it
 	// is cheaper to slice a string.  Further, it is not safe to convert
@@ -129,7 +129,6 @@ func (uuid UUID) Variant() Variant {
 }
 
 // Version returns the version of uuid.
-// valid.
 func (uuid UUID) Version() Version {
 	return Version(uuid[6] >> 4)
 }

--- a/version1.go
+++ b/version1.go
@@ -13,7 +13,7 @@ import (
 // or SetNodeInterface then it will be set automatically.  If the NodeID cannot
 // be set NewUUID returns nil.  If clock sequence has not been set by
 // SetClockSequence then it will be set automatically.  If GetTime fails to
-// return the current NewUUID returns an error.
+// return the current NewUUID returns NIL and an error.
 //
 // In most cases, New should be used.
 func NewUUID() (UUID, error) {

--- a/version1.go
+++ b/version1.go
@@ -13,7 +13,7 @@ import (
 // or SetNodeInterface then it will be set automatically.  If the NodeID cannot
 // be set NewUUID returns nil.  If clock sequence has not been set by
 // SetClockSequence then it will be set automatically.  If GetTime fails to
-// return the current NewUUID returns nil.
+// return the current NewUUID returns an error.
 //
 // In most cases, New should be used.
 func NewUUID() (UUID, error) {


### PR DESCRIPTION
I found several typos and outdated bits in the godoc comments. One weird bit the spurious piece commenting UUID.Version(). I couldn't figure out what that was about but figured it was unwanted.

I also made the method receiver names consistent across the package (changing them from `u` in marshal.go). It aligns the names a bit better when looking at [godoc.org](https://godoc.org/github.com/google/uuid). It also removes some of the warnings emitted from tools like `golint`.