### PR TITLE
version4: Typo in 'New' doc

### DIFF
--- a/version4.go
+++ b/version4.go
@@ -6,7 +6,7 @@ package uuid
 
 import "io"
 
-// New is creates a new random UUID or panics.  New is equivalent to
+// New creates a new random UUID or panics.  New is equivalent to
 // the expression
 //
 //    uuid.Must(uuid.NewRandom())


### PR DESCRIPTION
Remove redundant 'is'.