### PR TITLE
A little error in the documentation of dce.go

### DIFF
--- a/dce.go
+++ b/dce.go
@@ -42,7 +42,7 @@ func NewDCESecurity(domain Domain, id uint32) (UUID, error) {
 // NewDCEPerson returns a DCE Security (Version 2) UUID in the person
 // domain with the id returned by os.Getuid.
 //
-//  NewDCEPerson(Person, uint32(os.Getuid()))
+//  NewDCESecurity(Person, uint32(os.Getuid()))
 func NewDCEPerson() (UUID, error) {
 	return NewDCESecurity(Person, uint32(os.Getuid()))
 }
@@ -50,7 +50,7 @@ func NewDCEPerson() (UUID, error) {
 // NewDCEGroup returns a DCE Security (Version 2) UUID in the group
 // domain with the id returned by os.Getgid.
 //
-//  NewDCEGroup(Group, uint32(os.Getgid()))
+//  NewDCESecurity(Group, uint32(os.Getgid()))
 func NewDCEGroup() (UUID, error) {
 	return NewDCESecurity(Group, uint32(os.Getgid()))
 }


### PR DESCRIPTION
I think that could be an error in the documentation of [NewDCEGroup](https://github.com/google/uuid/blob/281f560d28af7174109514e936f94c2ab2cb2823/dce.go#L53) and [NewDCEPerson](https://github.com/google/uuid/blob/281f560d28af7174109514e936f94c2ab2cb2823/dce.go#L45)