### PR TITLE
Remove never-true conditional

### DIFF
--- a/node.go
+++ b/node.go
@@ -94,9 +94,6 @@ func SetNodeID(id []byte) bool {
 // NodeID returns the 6 byte node id encoded in uuid.  It returns nil if uuid is
 // not valid.  The NodeID is only well defined for version 1 and 2 UUIDs.
 func (uuid UUID) NodeID() []byte {
-	if len(uuid) != 16 {
-		return nil
-	}
 	var node [6]byte
 	copy(node[:], uuid[10:])
 	return node[:]


### PR DESCRIPTION
Please take a look.

This looks like it was missed when the `[]byte`=>`[16]byte` change was made.