### PR TITLE
add MustParse(), which returns an UUID or panics

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -97,6 +97,16 @@ func ParseBytes(b []byte) (UUID, error) {
 	return uuid, nil
 }
 
+// MustParse is like Parse but panics if the string cannot be parsed.
+// It simplifies safe initialization of global variables holding compiled UUIDs.
+func MustParse(s string) UUID {
+	uuid, err := Parse(s)
+	if err != nil {
+		panic(`uuid: Parse(` + s + `): ` + err.Error())
+	}
+	return uuid
+}
+
 // FromBytes creates a new UUID from a byte slice. Returns an error if the slice
 // does not have a length of 16. The bytes are copied from the slice.
 func FromBytes(b []byte) (uuid UUID, err error) {


### PR DESCRIPTION
Same usability as with https://golang.org/pkg/regexp/#MustCompile

```go
var someUUID = uuid.MustParse("f47ac10b-58cc-0372-8567-0e02b2c3d479")
```