### PR TITLE
add go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/google/uuid


### PR DESCRIPTION
PR adds a `go.mod` file (one-liner - package name only) and enables building and testing the package outside of GOPATH with go1.11.