### PR TITLE
uuid.MustParse should panic error in error type

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -139,7 +139,7 @@ func ParseBytes(b []byte) (UUID, error) {
 func MustParse(s string) UUID {
 	uuid, err := Parse(s)
 	if err != nil {
-		panic(`uuid: Parse(` + s + `): ` + err.Error())
+		panic(errors.New(`uuid: Parse(` + s + `): ` + err.Error()))
 	}
 	return uuid
 }


### PR DESCRIPTION
Currently MustParse panic the error in string type,

panic should be an error type, so the recover can have consistance use of err.Error()