### PR TITLE
Add sample usage to doc.go

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -9,4 +9,19 @@
 //
 // A UUID is a 16 byte (128 bit) array.  UUIDs may be used as keys to
 // maps or compared directly.
+// 
+// Sample usage:
+// 
+//       package main
+//
+//       import (
+//         "fmt"
+//
+//         "github.com/google/uuid"
+//       )
+//
+//       func main() {
+//         id := uuid.New()
+//         fmt.Println("id:", id.String())
+//       }
 package uuid


### PR DESCRIPTION
Hello! It took me a bit of time to figure out how to make a `UUID` glancing at the documentation because `uuid.New()` is listed as a subfunction of `type UUID`. I thought it might be nice to put a hello world example in the godoc.