### PR TITLE
Fixed masking of version bits

### DIFF
--- a/version4.go
+++ b/version4.go
@@ -37,7 +37,7 @@ func NewRandomFromReader(r io.Reader) (UUID, error) {
 	if err != nil {
 		return Nil, err
 	}
-	uuid[6] = (uuid[6] & 0xf) | 0x40 // Version 4
+	uuid[6] = (uuid[6] & 0xf0) | 0x40 // Version 4
 	uuid[8] = (uuid[8] & 0x3f) | 0x80 // Variant is 10
 	return uuid, nil
 }

--- a/version4.go
+++ b/version4.go
@@ -37,7 +37,7 @@ func NewRandomFromReader(r io.Reader) (UUID, error) {
 	if err != nil {
 		return Nil, err
 	}
-	uuid[6] = (uuid[6] & 0x0f) | 0x40 // Version 4
+	uuid[6] = (uuid[6] & 0xf) | 0x40 // Version 4
 	uuid[8] = (uuid[8] & 0x3f) | 0x80 // Variant is 10
 	return uuid, nil
 }


### PR DESCRIPTION
Instead of masking the 4 most significant bits (0xf0) the 4 least significant bits were masked (0x0f) and then or'ed with 0x40.