### PR TITLE
Fixed masking the signature bits of version 4

### DIFF
--- a/version4.go
+++ b/version4.go
@@ -37,7 +37,7 @@ func NewRandomFromReader(r io.Reader) (UUID, error) {
 	if err != nil {
 		return Nil, err
 	}
-	uuid[6] = (uuid[6] & 0x0f) | 0x40 // Version 4
-	uuid[8] = (uuid[8] & 0x3f) | 0x80 // Variant is 10
+	uuid[6] = (uuid[6] & 0xf0) | 0x40 // Version 4
+	uuid[8] = (uuid[8] & 0xc0) | 0x80 // Variant is 10
 	return uuid, nil
 }


### PR DESCRIPTION
The masking of the bits to add the signature of the version 4 uuid is wrong.
uuid[6] & 0x0f should be uuid[6] & 0xf0
and
uuid[8] & 0x3f should be uuid[8] & 0xc0