### PR TITLE
Added fuzzer and integrated with oss-fuzz

### DIFF
--- a/fuzz/fuzz.go
+++ b/fuzz/fuzz.go
@@ -1,0 +1,15 @@
+// Copyright 2020 Google Inc.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package fuzz
+
+import "github.com/google/uuid"
+
+func Fuzz(data []byte) int {
+	_, err := uuid.Parse(string(data))
+	if err != nil {
+		return 0
+	}
+	return 1
+}


### PR DESCRIPTION
This PR adds a fuzzer for uuid.

I have setup uuid in oss-fuzz as well: https://github.com/google/oss-fuzz/pull/3825

If there is interest in completing that integration, we are in need of the email addresses of maintainers of uuid that should receive the bug reports if a bug is found.