### PR TITLE
When parsing a 38-char UUID, require '{' and '}' characters

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -55,6 +55,9 @@ func Parse(s string) (UUID, error) {
 
 	// {xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}
 	case 36 + 2:
+		if s[0] != '{' || s[37] != '}' {
+			return uuid, fmt.Errorf("invalid prefix/suffix: got %q and %q, want '{' and '}'", s[0], s[37])
+		}
 		s = s[1:]
 
 	// xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
@@ -101,6 +104,9 @@ func ParseBytes(b []byte) (UUID, error) {
 		}
 		b = b[9:]
 	case 36 + 2: // {xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}
+		if b[0] != '{' || b[37] != '}' {
+			return uuid, fmt.Errorf("invalid prefix/suffix: got %q and %q, want '{' and '}'", b[0], b[37])
+		}
 		b = b[1:]
 	case 32: // xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 		var ok bool

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -67,6 +67,9 @@ var tests = []test{
 	{"g47ac10b-58cc-4372-a567-0e02b2c3d479", 0, Invalid, false},
 
 	{"{f47ac10b-58cc-0372-8567-0e02b2c3d479}", 0, RFC4122, true},
+	{"[f47ac10b-58cc-0372-8567-0e02b2c3d479]", 0, Invalid, false},
+	{"{f47ac10b-58cc-0372-8567-0e02b2c3d479]", 0, Invalid, false},
+	{"[f47ac10b-58cc-0372-8567-0e02b2c3d479}", 0, Invalid, false},
 	{"{f47ac10b-58cc-0372-8567-0e02b2c3d479", 0, Invalid, false},
 	{"f47ac10b-58cc-0372-8567-0e02b2c3d479}", 0, Invalid, false},
 


### PR DESCRIPTION
It was not intentional to simply ignore these characters, and
examples/docs/tests all indicate that curly braces were the intended
characters. I've added some test cases to ensure things work.

Fixes https://github.com/google/uuid/issues/60