### PR TITLE
Reduce custom error allocation

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -37,7 +37,7 @@ var rander = rand.Reader // random function
 
 type invalidLengthError struct{ len int }
 
-func (err *invalidLengthError) Error() string {
+func (err invalidLengthError) Error() string {
 	return fmt.Sprintf("invalid UUID length: %d", err.len)
 }
 
@@ -74,7 +74,7 @@ func Parse(s string) (UUID, error) {
 		}
 		return uuid, nil
 	default:
-		return uuid, &invalidLengthError{len(s)}
+		return uuid, invalidLengthError{len(s)}
 	}
 	// s is now at least 36 bytes long
 	// it must be of the form  xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
@@ -118,7 +118,7 @@ func ParseBytes(b []byte) (UUID, error) {
 		}
 		return uuid, nil
 	default:
-		return uuid, &invalidLengthError{len(b)}
+		return uuid, invalidLengthError{len(b)}
 	}
 	// s is now at least 36 bytes long
 	// it must be of the form  xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx


### PR DESCRIPTION
Zero allocation by using non-pointer error.

related #69

```
name               old time/op    new time/op    delta
ParseBadLength-16    15.4ns ± 0%     3.5ns ± 0%   ~     (p=1.000 n=1+1)

name               old alloc/op   new alloc/op   delta
ParseBadLength-16     8.00B ± 0%     0.00B        ~     (p=1.000 n=1+1)

name               old allocs/op  new allocs/op  delta
ParseBadLength-16      1.00 ± 0%      0.00        ~     (p=1.000 n=1+1)
```