### PR TITLE
Add NewString Func

### DIFF
--- a/version4.go
+++ b/version4.go
@@ -14,6 +14,14 @@ func New() UUID {
 	return Must(NewRandom())
 }
 
+// NewString creates a new random UUID and returns it as a string or panics.
+// NewString is equivalent to the expression
+//
+//    uuid.Must(uuid.NewRandom()).String()
+func NewString() string {
+	return New().String()
+}
+
 // NewRandom returns a Random (Version 4) UUID.
 //
 // The strength of the UUIDs is based on the strength of the crypto/rand

--- a/version4.go
+++ b/version4.go
@@ -17,9 +17,9 @@ func New() UUID {
 // NewString creates a new random UUID and returns it as a string or panics.
 // NewString is equivalent to the expression
 //
-//    uuid.Must(uuid.NewRandom()).String()
+//    uuid.New().String()
 func NewString() string {
-	return New().String()
+	return Must(NewRandom()).String()
 }
 
 // NewRandom returns a Random (Version 4) UUID.


### PR DESCRIPTION
- Adds `NewString()` func, which encapsulates the more verbose `New().String()`
- We use `New().String()` for testing, and it feels ugly. Rather than adding a wrapper around `google/uuid`, figured it makes sense to add the utility method to the root package