### PR TITLE
Add support for little-endian byte order representation.

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -36,3 +36,30 @@ func (uuid *UUID) UnmarshalBinary(data []byte) error {
 	copy(uuid[:], data)
 	return nil
 }
+
+// MarshalBinaryLittleEndian implements encoding.BinaryMarshaler.
+func (uuid UUID) MarshalBinaryLittleEndian() ([]byte, error) {
+	var uuidLittleEndian UUID = UUID {
+		// convert first 3 fields from big-endian to little-endian
+		uuid[3], uuid[2], uuid[1], uuid[0],
+		uuid[5], uuid[4],
+		uuid[7], uuid[6],
+	}
+	// all the rest fields keep byte order
+	copy(uuidLittleEndian[8:], uuid[8:])
+	return uuidLittleEndian[:], nil
+}
+
+// UnmarshalBinaryLittleEndian implements encoding.BinaryUnmarshaler.
+func (uuid *UUID) UnmarshalBinaryLittleEndian(data []byte) error {
+	if len(data) != 16 {
+		return fmt.Errorf("invalid UUID (got %d bytes)", len(data))
+	}
+	// convert first 3 fields from little-endian to big-endian
+	uuid[0] = data[3]; uuid[1] = data[2]; uuid[2] = data[1]; uuid[3] = data[0]
+	uuid[4] = data[5]; uuid[5] = data[4]
+	uuid[6] = data[7]; uuid[7] = data[6]
+	// all the rest fields keep byte order
+	copy(uuid[8:], data[8:])
+	return nil
+}

--- a/uuid.go
+++ b/uuid.go
@@ -157,6 +157,14 @@ func FromBytes(b []byte) (uuid UUID, err error) {
 	return uuid, err
 }
 
+// FromBytesLittleEndian creates a new UUID from a byte slice with little-endian
+// byte encoding for the first three fields. Returns an error if the slice
+// does not have a length of 16. The bytes are copied from the slice.
+func FromBytesLittleEndian(b []byte) (uuid UUID, err error) {
+	err = uuid.UnmarshalBinaryLittleEndian(b)
+	return uuid, err
+}
+
 // Must returns uuid if err is nil and panics otherwise.
 func Must(uuid UUID, err error) UUID {
 	if err != nil {


### PR DESCRIPTION
Although RFC4122 recommends network byte order for all fields, the PC industry (including the ACPI, UEFI, SMBIOS and Microsoft specifications) has consistently used little-endian byte encoding for the first three fields: time_low, time_mid, time_hi_and_version.
Example from SMBIOS spec, section 7.2.1 System - UUID
The UUID {00112233-4455-6677-8899-AABBCCDDEEFF} would thus be represented as: 33 22 11 00 55 44 77 66 88 99 AA BB CC DD EE FF
https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.4.0.pdf