### PR TITLE
feat: add public matcher function for custom error type invalidLengthError

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -41,6 +41,12 @@ func (err invalidLengthError) Error() string {
 	return fmt.Sprintf("invalid UUID length: %d", err.len)
 }
 
+// IsInvalidLengthError is matcher function for custom error invalidLengthError
+func IsInvalidLengthError(err error) bool {
+	_, ok := err.(invalidLengthError)
+	return ok
+}
+
 // Parse decodes s into a UUID or returns an error.  Both the standard UUID
 // forms of xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx and
 // urn:uuid:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx are decoded as well as the

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -526,6 +526,13 @@ func TestWrongLength(t *testing.T) {
 	}
 }
 
+func TestIsWrongLength(t *testing.T) {
+	_, err := Parse("12345")
+	if !IsInvalidLengthError(err) {
+		t.Errorf("expected error type is invalidLengthError")
+	}
+}
+
 var asString = "f47ac10b-58cc-0372-8567-0e02b2c3d479"
 var asBytes = []byte(asString)
 


### PR DESCRIPTION
This change will add matcher function for custom error type invalidLengthError, it is needed to expose the matcher function as public function.