### PR TITLE
Add `ReadRandom` and reimplement `NewRandomFromReader` using it

### DIFF
--- a/uuid_test.go
+++ b/uuid_test.go
@@ -5,6 +5,7 @@
 package uuid
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"os"
@@ -694,6 +695,19 @@ func BenchmarkUUID_NewPooled(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			_, err := NewRandom()
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func BenchmarkUUID_BufioReadRandom(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		r := bufio.NewReaderSize(rander, randPoolSize)
+		var uuid UUID
+		for pb.Next() {
+			err := ReadRandom(r, &uuid)
 			if err != nil {
 				b.Fatal(err)
 			}


### PR DESCRIPTION
Combined with e.g. `bufio.Reader` this provides fast zero-allocation
UUID generation if you do not consider heap memory particularly
sensitive, without a global state or lock.

I guess this is my proposal re. the discussion about #80/#85/#86/#88. It's faster than both of them and the single new function opens up other optimization possibilities they don't, e.g. if you already have some pathological `[1000]UUID` you need to fill.

I didn't remove the original pool implementation because in the end that's a question of the module's specific commitment to its API compatibility rather than a technical one.