### PR TITLE
Update UUID.String() documentation

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -180,8 +180,7 @@ func Must(uuid UUID, err error) UUID {
 	return uuid
 }
 
-// String returns the string form of uuid, xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-// , or "" if uuid is invalid.
+// String returns the string form of uuid, xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx.
 func (uuid UUID) String() string {
 	var buf [36]byte
 	encodeHex(buf[:], uuid)


### PR DESCRIPTION
Currently the UUID.String() method does not return an empty string, but the documentation says so.