### PR TITLE
fix: use MustParse("xxx") instead of Must(Parse("xxxx"))

### DIFF
--- a/hash.go
+++ b/hash.go
@@ -12,10 +12,10 @@ import (
 
 // Well known namespace IDs and UUIDs
 var (
-	NameSpaceDNS  = Must(Parse("6ba7b810-9dad-11d1-80b4-00c04fd430c8"))
-	NameSpaceURL  = Must(Parse("6ba7b811-9dad-11d1-80b4-00c04fd430c8"))
-	NameSpaceOID  = Must(Parse("6ba7b812-9dad-11d1-80b4-00c04fd430c8"))
-	NameSpaceX500 = Must(Parse("6ba7b814-9dad-11d1-80b4-00c04fd430c8"))
+	NameSpaceDNS  = MustParse("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+	NameSpaceURL  = MustParse("6ba7b811-9dad-11d1-80b4-00c04fd430c8")
+	NameSpaceOID  = MustParse("6ba7b812-9dad-11d1-80b4-00c04fd430c8")
+	NameSpaceX500 = MustParse("6ba7b814-9dad-11d1-80b4-00c04fd430c8")
 	Nil           UUID // empty UUID, all zeros
 )
 

--- a/json_test.go
+++ b/json_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 )
 
-var testUUID = Must(Parse("f47ac10b-58cc-0372-8567-0e02b2c3d479"))
+var testUUID = MustParse("f47ac10b-58cc-0372-8567-0e02b2c3d479")
 
 func TestJSON(t *testing.T) {
 	type S struct {

--- a/sql_test.go
+++ b/sql_test.go
@@ -15,7 +15,7 @@ func TestScan(t *testing.T) {
 	invalidTest := "f47ac10b-58cc-0372-8567-0e02b2c3d4"
 
 	byteTest := make([]byte, 16)
-	byteTestUUID := Must(Parse(stringTest))
+	byteTestUUID := MustParse(stringTest)
 	copy(byteTest, byteTestUUID[:])
 
 	// sunny day tests
@@ -105,7 +105,7 @@ func TestScan(t *testing.T) {
 
 func TestValue(t *testing.T) {
 	stringTest := "f47ac10b-58cc-0372-8567-0e02b2c3d479"
-	uuid := Must(Parse(stringTest))
+	uuid := MustParse(stringTest)
 	val, _ := uuid.Value()
 	if val != stringTest {
 		t.Error("Value() did not return expected string")


### PR DESCRIPTION


`Must(Parse("xxxx"))` is considered legacy code to forced uuid to parse because the code is pre-implementation of `Must(Parase("xxxx")) `(https://github.com/google/uuid/pull/26)

This one is simpler.