### PR TITLE
chore(ci): add Action-based tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Code owners file.
+# This file controls who is tagged for review for any given pull request.
+
+# For syntax help see:
+# https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
+* @google/go-uuid-contributors

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,18 @@
+---
+name: tests
+on:
+  pull_request:
+    branches:
+      - master
+jobs:
+  unit-tests:
+    strategy:
+      matrix:
+        go-version: [1.19, 1.20, 1.21]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go-version }}
+      - run: go test -v ./...

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,7 +8,7 @@ jobs:
   unit-tests:
     strategy:
       matrix:
-        go-version: [1.19, 1.20, 1.21]
+        go-version: [1.19, 1.20.x, 1.21]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: go
-
-go:
-  - 1.4.3
-  - 1.5.3
-  - tip
-
-script:
-  - go test -v ./...

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# uuid ![build status](https://travis-ci.org/google/uuid.svg?branch=master)
+# uuid
 The uuid package generates and inspects UUIDs based on
 [RFC 4122](http://tools.ietf.org/html/rfc4122)
 and DCE 1.1: Authentication and Security Services. 


### PR DESCRIPTION
* Removes `travis.yml`
* Removes Travis badge
* Adds `CODEOWNERS` set to @google/go-uuid-contributors 
* Adds Action workflow for tests
  * add job to run tests over most recent three Go versions