### PR TITLE
chore(ci): add apidiff check for API compatibility

### DIFF
--- a/.github/workflows/apidiff.yaml
+++ b/.github/workflows/apidiff.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.20.x
+          go-version: 1.21
       - run: go install golang.org/x/exp/cmd/apidiff@latest
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/apidiff.yaml
+++ b/.github/workflows/apidiff.yaml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.21
+          go-version: 1.20.x
       - run: go install golang.org/x/exp/cmd/apidiff@latest
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/apidiff.yaml
+++ b/.github/workflows/apidiff.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
 jobs:
-  check:
+  compat:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v4

--- a/.github/workflows/apidiff.yaml
+++ b/.github/workflows/apidiff.yaml
@@ -20,5 +20,5 @@ jobs:
         with:
           clean: false
       - run: |
-          apidiff -m -incompatible uuid.baseline . > diff.txt
+          apidiff -incompatible uuid.baseline . > diff.txt
           cat diff.txt && ! [ -s diff.txt ]

--- a/.github/workflows/apidiff.yaml
+++ b/.github/workflows/apidiff.yaml
@@ -1,0 +1,24 @@
+---
+name: apidiff
+on:
+  pull_request:
+    branches:
+      - master
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.21
+      - run: go install golang.org/x/exp/cmd/apidiff@latest
+      - uses: actions/checkout@v3
+        with:
+          ref: master
+      - run: apidiff -w uuid.baseline .
+      - uses: actions/checkout@v3
+        with:
+          clean: false
+      - run: |
+          apidiff -m -incompatible uuid.baseline . > diff.txt
+          cat diff.txt && ! [ -s diff.txt ]

--- a/uuid.go
+++ b/uuid.go
@@ -69,7 +69,7 @@ func Parse(s string) (UUID, error) {
 
 	// urn:uuid:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 	case 36 + 9:
-		if strings.ToLower(s[:9]) != "urn:uuid:" {
+		if !strings.EqualFold(s[:9], "urn:uuid:") {
 			return uuid, fmt.Errorf("invalid urn prefix: %q", s[:9])
 		}
 		s = s[9:]
@@ -101,7 +101,8 @@ func Parse(s string) (UUID, error) {
 		9, 11,
 		14, 16,
 		19, 21,
-		24, 26, 28, 30, 32, 34} {
+		24, 26, 28, 30, 32, 34,
+	} {
 		v, ok := xtob(s[x], s[x+1])
 		if !ok {
 			return uuid, errors.New("invalid UUID format")
@@ -117,7 +118,7 @@ func ParseBytes(b []byte) (UUID, error) {
 	switch len(b) {
 	case 36: // xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 	case 36 + 9: // urn:uuid:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-		if !bytes.Equal(bytes.ToLower(b[:9]), []byte("urn:uuid:")) {
+		if !bytes.EqualFold(b[:9], []byte("urn:uuid:")) {
 			return uuid, fmt.Errorf("invalid urn prefix: %q", b[:9])
 		}
 		b = b[9:]
@@ -145,7 +146,8 @@ func ParseBytes(b []byte) (UUID, error) {
 		9, 11,
 		14, 16,
 		19, 21,
-		24, 26, 28, 30, 32, 34} {
+		24, 26, 28, 30, 32, 34,
+	} {
 		v, ok := xtob(b[x], b[x+1])
 		if !ok {
 			return uuid, errors.New("invalid UUID format")


### PR DESCRIPTION
Adds a GitHub Action workflow for running [`apidiff`](https://pkg.go.dev/golang.org/x/exp/apidiff). This will protect against backwards incompatible changes to this modules public API.