### PR TITLE
docs: change godoc URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ go get github.com/google/uuid
 ```
 
 ###### Documentation 
-[![GoDoc](https://godoc.org/github.com/google/uuid?status.svg)](http://godoc.org/github.com/google/uuid)
+[![Go Reference](https://pkg.go.dev/badge/github.com/google/uuid.svg)](https://pkg.go.dev/github.com/google/uuid)
 
 Full `go doc` style documentation for the package can be viewed online without
 installing this package by using the GoDoc site here: 


### PR DESCRIPTION
This PR replaces `godoc.org` with `pkg.go.dev` in README.