### PR TITLE
chore(tests): add Fuzz tests

### DIFF
--- a/uuid_test.go
+++ b/uuid_test.go
@@ -569,6 +569,39 @@ func TestIsWrongLength(t *testing.T) {
 	}
 }
 
+func FuzzParse(f *testing.F) {
+	for _, tt := range tests {
+		f.Add(tt.in)
+		f.Add(strings.ToUpper(tt.in))
+	}
+	f.Fuzz(func(t *testing.T, in string) {
+		Parse(in)
+	})
+}
+
+func FuzzParseBytes(f *testing.F) {
+	for _, tt := range tests {
+		f.Add([]byte(tt.in))
+	}
+	f.Fuzz(func(t *testing.T, in []byte) {
+		ParseBytes(in)
+	})
+}
+
+func FuzzFromBytes(f *testing.F) {
+	// Copied from TestFromBytes.
+	f.Add([]byte{
+		0x7d, 0x44, 0x48, 0x40,
+		0x9d, 0xc0,
+		0x11, 0xd1,
+		0xb2, 0x45,
+		0x5f, 0xfd, 0xce, 0x74, 0xfa, 0xd2,
+	})
+	f.Fuzz(func(t *testing.T, in []byte) {
+		FromBytes(in)
+	})
+}
+
 var asString = "f47ac10b-58cc-0372-8567-0e02b2c3d479"
 var asBytes = []byte(asString)
 


### PR DESCRIPTION
Add Go-native Fuzz tests for `Parse`, `ParseBytes`, and `FromBytes`.

Ideally, we integrate this with OSS-Fuzz instead of running in our own CI.