### PR TITLE
feat: UUIDs slice type with Strings() convenience method

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -295,10 +295,10 @@ func DisableRandPool() {
 	poolPos = randPoolSize
 }
 
-// UUIDs is a slice of UUID types
+// UUIDs is a slice of UUID types.
 type UUIDs []UUID
 
-// Strings returns a slice of the string form of each UUID in the received slice of UUIDs
+// Strings returns a string slice containing the string form of each UUID in uuids.
 func (uuids UUIDs) Strings() []string {
 	var uuidStrs = make([]string, len(uuids))
 	for i, uuid := range uuids {

--- a/uuid.go
+++ b/uuid.go
@@ -294,3 +294,15 @@ func DisableRandPool() {
 	poolMu.Lock()
 	poolPos = randPoolSize
 }
+
+// UUIDs is a slice of UUID types
+type UUIDs []UUID
+
+// Strings returns a slice of the string form of each UUID in the received slice of UUIDs
+func (uuids UUIDs) Strings() []string {
+	var uuidStrs = make([]string, len(uuids))
+	for i, uuid := range uuids {
+		uuidStrs[i] = uuid.String()
+	}
+	return uuidStrs
+}

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -743,8 +743,8 @@ func BenchmarkUUIDs_Strings(b *testing.B) {
 	if err != nil {
 		b.Fatal(err)
 	}
-	uuids := uuid.UUIDs{uuid1, uuid2}
+	uuids := UUIDs{uuid1, uuid2}
 	for i := 0; i < b.N; i++ {
-		uuid.Strings()
+		uuids.Strings()
 	}
 }

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -733,3 +733,18 @@ func BenchmarkUUID_NewPooled(b *testing.B) {
 		}
 	})
 }
+
+func BenchmarkUUIDs_Strings(b *testing.B) {
+	uuid1, err := Parse("f47ac10b-58cc-0372-8567-0e02b2c3d479")
+	if err != nil {
+		b.Fatal(err)
+	}
+	uuid2, err := Parse("7d444840-9dc0-11d1-b245-5ffdce74fad2")
+	if err != nil {
+		b.Fatal(err)
+	}
+	uuids := uuid.UUIDs{uuid1, uuid2}
+	for i := 0; i < b.N; i++ {
+		uuid.Strings()
+	}
+}


### PR DESCRIPTION
I often work with slices of UUIDs and want to include them in log messages. It is therefore convenient to be able to easily transform a slice of UUIDs into a slice of strings. In the interest of avoiding repeating code across many projects to accomplish this, I suggest defining a slice type in this project. 

This PR adds such a type and defines a convenience method `Strings()` on it.

This type additionally gives maintainers the opportunity to add further convenience methods; for instance one could implement the sort interface on this new type.