### PR TITLE
chore: limit permissions for github workflows

### DIFF
--- a/.github/workflows/apidiff.yaml
+++ b/.github/workflows/apidiff.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   compat:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   unit-tests:
     strategy:


### PR DESCRIPTION
Closes #142 

Workflows running with the limited permissions:

- [tests.yml](https://github.com/joycebrum/uuid/actions/runs/7119437379)
- [apidiff.yml](https://github.com/joycebrum/uuid/actions/runs/7119437378)