### PR TITLE
docs: fixing typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ go get github.com/google/uuid
 
 Full `go doc` style documentation for the package can be viewed online without
 installing this package by using the GoDoc site here: 
-http://pkg.go.dev/github.com/google/uuid
+https://pkg.go.dev/github.com/google/uuid

--- a/null_test.go
+++ b/null_test.go
@@ -205,10 +205,10 @@ func TestNullUUIDUnmarshalJSON(t *testing.T) {
 	var nu NullUUID
 	err := json.Unmarshal(jsonNull, &nu)
 	if err != nil || nu.Valid {
-		t.Errorf("expected nil when unmarshaling null, got %s", err)
+		t.Errorf("expected nil when unmarshalling null, got %s", err)
 	}
 	err = json.Unmarshal(jsonUUID, &nu)
 	if err != nil || !nu.Valid {
-		t.Errorf("expected nil when unmarshaling null, got %s", err)
+		t.Errorf("expected nil when unmarshalling null, got %s", err)
 	}
 }

--- a/version7.go
+++ b/version7.go
@@ -83,7 +83,7 @@ var lastV7time int64
 const nanoPerMilli = 1000000
 
 // getV7Time returns the time in milliseconds and nanoseconds / 256.
-// The returned (milli << 12 + seq) is guarenteed to be greater than
+// The returned (milli << 12 + seq) is guaranteed to be greater than
 // (milli << 12 + seq) returned by any previous call to getV7Time.
 func getV7Time() (milli, seq int64) {
 	timeMu.Lock()


### PR DESCRIPTION
This PR fixes two typos I spotted in the code base and changes one link from `http` to `https` protocol.