### PR TITLE
Moved NewV7FromReader to uuid_test since it shouldn't be used outside of testing

### DIFF
--- a/uuid_test.go
+++ b/uuid_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"runtime"
 	"strings"
@@ -882,6 +883,19 @@ func TestVersion7FromReader(t *testing.T) {
 	if err == nil {
 		t.Errorf("expecting an error as reader has no more bytes. Got uuid. NewV7FromReader may not be using the provided reader")
 	}
+}
+
+// NewV7FromReader returns a Version 7 UUID based on the current time and uses
+// NewRandomFromReader to get bytes 8-15 of the UUID.
+// On error, NewV7FromReader returns Nil and an error.
+func NewV7FromReader(r io.Reader) (UUID, error) {
+	uuid, err := NewRandomFromReader(r)
+	if err != nil {
+		return uuid, err
+	}
+
+	makeV7(uuid[:])
+	return uuid, nil
 }
 
 func TestVersion7Monotonicity(t *testing.T) {

--- a/version7.go
+++ b/version7.go
@@ -4,10 +4,6 @@
 
 package uuid
 
-import (
-	"io"
-)
-
 // UUID version 7 features a time-ordered value field derived from the widely
 // implemented and well known Unix Epoch timestamp source,
 // the number of milliseconds seconds since midnight 1 Jan 1970 UTC, leap seconds excluded.
@@ -25,19 +21,6 @@ func NewV7() (UUID, error) {
 	if err != nil {
 		return uuid, err
 	}
-	makeV7(uuid[:])
-	return uuid, nil
-}
-
-// NewV7FromReader returns a Version 7 UUID based on the current time(Unix Epoch).
-// it use NewRandomFromReader fill random bits.
-// On error, NewV7FromReader returns Nil and an error.
-func NewV7FromReader(r io.Reader) (UUID, error) {
-	uuid, err := NewRandomFromReader(r)
-	if err != nil {
-		return uuid, err
-	}
-
 	makeV7(uuid[:])
 	return uuid, nil
 }


### PR DESCRIPTION
This function was in the version7.go file but it looks like it should only be available during testing. Leaving the function in the public API leaves open the possibility of people using it incorrectly and getting bad UUID v7 values.