### PR TITLE
fix incorrect timestamp in uuid v6

### DIFF
--- a/time.go
+++ b/time.go
@@ -113,7 +113,9 @@ func (uuid UUID) Time() Time {
 	var t Time
 	switch uuid.Version() {
 	case 6:
-		time := binary.BigEndian.Uint64(uuid[:8]) // Ignore uuid[6] version b0110
+		time := int64(binary.BigEndian.Uint32(uuid[0:4])) << 28
+		time |= int64(binary.BigEndian.Uint16(uuid[4:6])) << 12
+		time |= int64(binary.BigEndian.Uint16(uuid[6:8]) & 0xfff)
 		t = Time(time)
 	case 7:
 		time := binary.BigEndian.Uint64(uuid[:8])

--- a/version6.go
+++ b/version6.go
@@ -39,11 +39,15 @@ func NewV6() (UUID, error) {
 	   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 	*/
 
-	binary.BigEndian.PutUint64(uuid[0:], uint64(now))
-	binary.BigEndian.PutUint16(uuid[8:], seq)
+	timeHigh := uint32((now >> 28) & 0xffffffff)
+	timeMid := uint16((now >> 12) & 0xffff)
+	timeLow := uint16(now & 0x0fff)
+	timeLow |= 0x6000 // Version 6
 
-	uuid[6] = 0x60 | (uuid[6] & 0x0F)
-	uuid[8] = 0x80 | (uuid[8] & 0x3F)
+	binary.BigEndian.PutUint32(uuid[0:], timeHigh)
+	binary.BigEndian.PutUint16(uuid[4:], timeMid)
+	binary.BigEndian.PutUint16(uuid[6:], timeLow)
+	binary.BigEndian.PutUint16(uuid[8:], seq)
 
 	nodeMu.Lock()
 	if nodeID == zeroID {


### PR DESCRIPTION
The timestamp part of the uuid v6 implementation is incorrect.

The only lower 60 bits of the timestamp from `GetTime` should be used,
but current implementation put entire 64-bit timestamp and overwrite the lower 4-bit part with the version ID.

Therefore, it is not field-compatible with version 1.

```
V1 timestamp
     <----high---> <------mid------> <----------------low-------------->
|xxxx0000|00000000|00000000|00000000|00000000|00000000|00000000|00000000|

V6 timestamp
     <----------------high--------------><-------mid------><----low---->
|xxxx0000|00000000|00000000|00000000|00000000|00000000|00000000|00000000|

Current implementation for V6 timestamp
 <---------------high--------------> <-------mid----->     <----low---->
|xxxx0000|00000000|00000000|00000000|00000000|00000000|00000000|00000000|
```

Also, we don't need to add variant field at `uuid[8]`, as it is already filled by `getTime`.
