### PR TITLE
docs: upd links to rfc9562

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # uuid
 The uuid package generates and inspects UUIDs based on
-[RFC 4122](https://datatracker.ietf.org/doc/html/rfc4122)
+[RFC 9562](https://datatracker.ietf.org/doc/html/rfc9562)
 and DCE 1.1: Authentication and Security Services. 
 
 This package is based on the github.com/pborman/uuid package (previously named

--- a/doc.go
+++ b/doc.go
@@ -4,7 +4,7 @@
 
 // Package uuid generates and inspects UUIDs.
 //
-// UUIDs are based on RFC 4122 and DCE 1.1: Authentication and Security
+// UUIDs are based on RFC 9562(obsoletes RFC 4122) and DCE 1.1: Authentication and Security
 // Services.
 //
 // A UUID is a 16 byte (128 bit) array.  UUIDs may be used as keys to

--- a/hash.go
+++ b/hash.go
@@ -38,7 +38,7 @@ func NewHash(h hash.Hash, space UUID, data []byte, version int) UUID {
 	var uuid UUID
 	copy(uuid[:], s)
 	uuid[6] = (uuid[6] & 0x0f) | uint8((version&0xf)<<4)
-	uuid[8] = (uuid[8] & 0x3f) | 0x80 // RFC 4122 variant
+	uuid[8] = (uuid[8] & 0x3f) | 0x80 // RFC 9562 variant
 	return uuid
 }
 

--- a/uuid.go
+++ b/uuid.go
@@ -16,7 +16,7 @@ import (
 )
 
 // A UUID is a 128 bit (16 byte) Universal Unique IDentifier as defined in RFC
-// 4122.
+// 9562.
 type UUID [16]byte
 
 // A Version represents a UUID's version.
@@ -28,11 +28,16 @@ type Variant byte
 // Constants returned by Variant.
 const (
 	Invalid   = Variant(iota) // Invalid UUID
-	RFC4122                   // The variant specified in RFC4122
+	RFC4122                   // The variant specified in RFC9562(obsoletes RFC4122).
 	Reserved                  // Reserved, NCS backward compatibility.
 	Microsoft                 // Reserved, Microsoft Corporation backward compatibility.
 	Future                    // Reserved for future definition.
 )
+
+// RFC9562 added V6 and V7 of UUID, but did not change specification of V1 and V4
+// implemented in this module. To avoid creating new major module version,
+// we still use RFC4122 for constant name.
+const Standard = RFC4122
 
 const randPoolSize = 16 * 16
 
@@ -57,7 +62,7 @@ func IsInvalidLengthError(err error) bool {
 }
 
 // Parse decodes s into a UUID or returns an error if it cannot be parsed.  Both
-// the standard UUID forms defined in RFC 4122
+// the standard UUID forms defined in RFC 9562
 // (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx and
 // urn:uuid:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) are decoded.  In addition,
 // Parse accepts non-standard strings such as the raw hex encoding

--- a/version6.go
+++ b/version6.go
@@ -10,7 +10,7 @@ import "encoding/binary"
 // It is expected that UUIDv6 will primarily be used in contexts where there are existing v1 UUIDs.
 // Systems that do not involve legacy UUIDv1 SHOULD consider using UUIDv7 instead.
 //
-// see https://datatracker.ietf.org/doc/html/draft-peabody-dispatch-new-uuid-format-03#uuidv6
+// see https://datatracker.ietf.org/doc/html/rfc9562#uuidv6
 //
 // NewV6 returns a Version 6 UUID based on the current NodeID and clock
 // sequence, and the current time. If the NodeID has not been set by SetNodeID

--- a/version7.go
+++ b/version7.go
@@ -13,7 +13,7 @@ import (
 // the number of milliseconds seconds since midnight 1 Jan 1970 UTC, leap seconds excluded.
 // As well as improved entropy characteristics over versions 1 or 6.
 //
-// see https://datatracker.ietf.org/doc/html/draft-peabody-dispatch-new-uuid-format-03#name-uuid-version-7
+// see https://datatracker.ietf.org/doc/html/rfc9562#name-uuid-version-7
 //
 // Implementations SHOULD utilize UUID version 7 over UUID version 1 and 6 if possible.
 //


### PR DESCRIPTION
RFC 9562 obsoletes RFC 4122.
https://datatracker.ietf.org/doc/html/rfc9562#name-update-motivation
