### PR TITLE
fix: uuid v7 monotonicity in rare case

### DIFF
--- a/version7.go
+++ b/version7.go
@@ -95,9 +95,16 @@ func getV7Time() (milli, seq int64) {
 	seq = (nano - milli*nanoPerMilli) >> 8
 	now := milli<<12 + seq
 	if now <= lastV7time {
-		now = lastV7time + 1
-		milli = now >> 12
-		seq = now & 0xfff
+		// uuid ver bits may eat seq carry
+		if seq == 0xfff {
+			milli = milli + 1
+			seq = 0
+			now = milli<<12 + seq
+		} else {
+			now = lastV7time + 1
+			milli = now >> 12
+			seq = now & 0xfff
+		}
 	}
 	lastV7time = now
 	return milli, seq


### PR DESCRIPTION
if `lastV7time & 0xfff == 0xfff `,  `(lastV7time + 1) & 0x000 == 0`, then `makeV7` generate a uuid v7 less than last time it generated.