### PR TITLE
chore(ci): test with latest go versions, update actions

### DIFF
--- a/.github/workflows/apidiff.yaml
+++ b/.github/workflows/apidiff.yaml
@@ -10,15 +10,15 @@ jobs:
   compat:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version: 'stable'
       - run: go install golang.org/x/exp/cmd/apidiff@latest
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: master
       - run: apidiff -w uuid.baseline .
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           clean: false
       - run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,11 +10,11 @@ jobs:
   unit-tests:
     strategy:
       matrix:
-        go-version: [1.19, 1.20.x, 1.21]
+        go-version: ['1.19', '1.20', '1.21', 'oldstable', 'stable']
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
       - run: go test -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/google/uuid
+
+go 1.16


### PR DESCRIPTION
This PR adds `oldstable, stable` to the list of versions the library is tested against. Currently, `oldstable` is `go1.22` and `stable` is `go1.23`. When the new Go version will be released, `oldstable` will become `go1.23` and `stable` will become `go1.24`.

The PR adds `go 1.16` in `go.mod` to explicitly state the minimum Go version supported by the library. The `go 1.16` is chosen because [the doc](https://go.dev/ref/mod#go-mod-file-go) states that "If the go directive is missing, go 1.16 is assumed".

Additionally, the PR updates the versions of `actions/setup-go` and `actions/checkout` to the latest.