### PR TITLE
chore: gofmt issues

### DIFF
--- a/dce.go
+++ b/dce.go
@@ -42,7 +42,7 @@ func NewDCESecurity(domain Domain, id uint32) (UUID, error) {
 // NewDCEPerson returns a DCE Security (Version 2) UUID in the person
 // domain with the id returned by os.Getuid.
 //
-//  NewDCESecurity(Person, uint32(os.Getuid()))
+//	NewDCESecurity(Person, uint32(os.Getuid()))
 func NewDCEPerson() (UUID, error) {
 	return NewDCESecurity(Person, uint32(os.Getuid()))
 }
@@ -50,7 +50,7 @@ func NewDCEPerson() (UUID, error) {
 // NewDCEGroup returns a DCE Security (Version 2) UUID in the group
 // domain with the id returned by os.Getgid.
 //
-//  NewDCESecurity(Group, uint32(os.Getgid()))
+//	NewDCESecurity(Group, uint32(os.Getgid()))
 func NewDCEGroup() (UUID, error) {
 	return NewDCESecurity(Group, uint32(os.Getgid()))
 }

--- a/hash.go
+++ b/hash.go
@@ -45,7 +45,7 @@ func NewHash(h hash.Hash, space UUID, data []byte, version int) UUID {
 // NewMD5 returns a new MD5 (Version 3) UUID based on the
 // supplied name space and data.  It is the same as calling:
 //
-//  NewHash(md5.New(), space, data, 3)
+//	NewHash(md5.New(), space, data, 3)
 func NewMD5(space UUID, data []byte) UUID {
 	return NewHash(md5.New(), space, data, 3)
 }
@@ -53,7 +53,7 @@ func NewMD5(space UUID, data []byte) UUID {
 // NewSHA1 returns a new SHA1 (Version 5) UUID based on the
 // supplied name space and data.  It is the same as calling:
 //
-//  NewHash(sha1.New(), space, data, 5)
+//	NewHash(sha1.New(), space, data, 5)
 func NewSHA1(space UUID, data []byte) UUID {
 	return NewHash(sha1.New(), space, data, 5)
 }

--- a/node_js.go
+++ b/node_js.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build js
 // +build js
 
 package uuid

--- a/node_net.go
+++ b/node_net.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !js
 // +build !js
 
 package uuid

--- a/null.go
+++ b/null.go
@@ -17,15 +17,14 @@ var jsonNull = []byte("null")
 // NullUUID implements the SQL driver.Scanner interface so
 // it can be used as a scan destination:
 //
-//  var u uuid.NullUUID
-//  err := db.QueryRow("SELECT name FROM foo WHERE id=?", id).Scan(&u)
-//  ...
-//  if u.Valid {
-//     // use u.UUID
-//  } else {
-//     // NULL value
-//  }
-//
+//	var u uuid.NullUUID
+//	err := db.QueryRow("SELECT name FROM foo WHERE id=?", id).Scan(&u)
+//	...
+//	if u.Valid {
+//	   // use u.UUID
+//	} else {
+//	   // NULL value
+//	}
 type NullUUID struct {
 	UUID  UUID
 	Valid bool // Valid is true if UUID is not NULL

--- a/uuid.go
+++ b/uuid.go
@@ -52,7 +52,7 @@ var (
 	ErrInvalidBracketedFormat = errors.New("invalid bracketed UUID format")
 )
 
-type URNPrefixError struct { prefix string }
+type URNPrefixError struct{ prefix string }
 
 func (e URNPrefixError) Error() string {
 	return fmt.Sprintf("invalid urn prefix: %q", e.prefix)
@@ -215,10 +215,12 @@ func Must(uuid UUID, err error) UUID {
 }
 
 // Validate returns an error if s is not a properly formatted UUID in one of the following formats:
-//   xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-//   urn:uuid:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-//   xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-//   {xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}
+//
+//	xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+//	urn:uuid:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+//	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+//	{xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}
+//
 // It returns an error if the format is invalid, otherwise nil.
 func Validate(s string) error {
 	switch len(s) {

--- a/version4.go
+++ b/version4.go
@@ -9,7 +9,7 @@ import "io"
 // New creates a new random UUID or panics.  New is equivalent to
 // the expression
 //
-//    uuid.Must(uuid.NewRandom())
+//	uuid.Must(uuid.NewRandom())
 func New() UUID {
 	return Must(NewRandom())
 }
@@ -17,7 +17,7 @@ func New() UUID {
 // NewString creates a new random UUID and returns it as a string or panics.
 // NewString is equivalent to the expression
 //
-//    uuid.New().String()
+//	uuid.New().String()
 func NewString() string {
 	return Must(NewRandom()).String()
 }
@@ -31,11 +31,11 @@ func NewString() string {
 //
 // A note about uniqueness derived from the UUID Wikipedia entry:
 //
-//  Randomly generated UUIDs have 122 random bits.  One's annual risk of being
-//  hit by a meteorite is estimated to be one chance in 17 billion, that
-//  means the probability is about 0.00000000006 (6 × 10−11),
-//  equivalent to the odds of creating a few tens of trillions of UUIDs in a
-//  year and having one duplicate.
+//	Randomly generated UUIDs have 122 random bits.  One's annual risk of being
+//	hit by a meteorite is estimated to be one chance in 17 billion, that
+//	means the probability is about 0.00000000006 (6 × 10−11),
+//	equivalent to the odds of creating a few tens of trillions of UUIDs in a
+//	year and having one duplicate.
 func NewRandom() (UUID, error) {
 	if !poolEnabled {
 		return NewRandomFromReader(rander)


### PR DESCRIPTION
This PR fixes `gofmt` issues on the latest Go 1.23 by running `go fmt .`