### PR TITLE
perf: Make the UUIDv7 implementation lock-free

### DIFF
--- a/uuid_test.go
+++ b/uuid_test.go
@@ -766,6 +766,29 @@ func BenchmarkUUID_NewPooled(b *testing.B) {
 	})
 }
 
+func BenchmarkUUID_NewV7(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, err := NewV7()
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+func BenchmarkUUID_NewV7Pooled(b *testing.B) {
+	EnableRandPool()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, err := NewV7()
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
 func BenchmarkUUIDs_Strings(b *testing.B) {
 	uuid1, err := Parse("f47ac10b-58cc-0372-8567-0e02b2c3d479")
 	if err != nil {


### PR DESCRIPTION
This lock-free implementation leverages atomic operations to avoid locking and context switching. Besides, it uses the sequence number exclusively, rather than relying on nanosecond-level information. Based on microbenchmarks, it can generate more UUIDv7 values within a given period of time.

Before:
```bash
go test -bench=BenchmarkUUID_NewV7 -benchtime=10s -run=NONE

goos: darwin
goarch: arm64
pkg: github.com/google/uuid
BenchmarkUUID_NewV7-8         	17931745	       664.1 ns/op
BenchmarkUUID_NewV7Pooled-8   	66918664	       180.4 ns/op
```

After:
```bash
go test -bench=BenchmarkUUID_NewV7 -benchtime=10s -run=NONE

goos: darwin
goarch: arm64
pkg: github.com/google/uuid
BenchmarkUUID_NewV7-8         	18219297	       655.6 ns/op
BenchmarkUUID_NewV7Pooled-8   	71690725	       167.7 ns/op
```