### PR TITLE
feat: Leverage the new `math/rand/v2` ChaCha8 CSPRNG

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -6,11 +6,15 @@ package uuid
 
 import (
 	"bytes"
-	"crypto/rand"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
+
+	// Uses math/rand/v2 for random number generation
+	// because it uses chacha8 as the default source,
+	// which is cryptographically secure and much faster
+	chacha8RandV2 "math/rand/v2"
 	"strings"
 	"sync"
 )
@@ -42,8 +46,8 @@ const Standard = RFC4122
 const randPoolSize = 16 * 16
 
 var (
-	rander      = rand.Reader // random function
-	poolEnabled = false
+	rander      io.Reader = defaultRandReader{}
+	poolEnabled           = false
 	poolMu      sync.Mutex
 	poolPos     = randPoolSize     // protected with poolMu
 	pool        [randPoolSize]byte // protected with poolMu
@@ -52,7 +56,7 @@ var (
 	ErrInvalidBracketedFormat = errors.New("invalid bracketed UUID format")
 )
 
-type URNPrefixError struct { prefix string }
+type URNPrefixError struct{ prefix string }
 
 func (e URNPrefixError) Error() string {
 	return fmt.Sprintf("invalid urn prefix: %q", e.prefix)
@@ -215,10 +219,12 @@ func Must(uuid UUID, err error) UUID {
 }
 
 // Validate returns an error if s is not a properly formatted UUID in one of the following formats:
-//   xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-//   urn:uuid:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-//   xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-//   {xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}
+//
+//	xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+//	urn:uuid:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+//	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+//	{xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}
+//
 // It returns an error if the format is invalid, otherwise nil.
 func Validate(s string) error {
 	switch len(s) {
@@ -346,7 +352,7 @@ func (v Variant) String() string {
 // generator.
 func SetRand(r io.Reader) {
 	if r == nil {
-		rander = rand.Reader
+		rander = defaultRandReader{}
 		return
 	}
 	rander = r
@@ -390,4 +396,26 @@ func (uuids UUIDs) Strings() []string {
 		uuidStrs[i] = uuid.String()
 	}
 	return uuidStrs
+}
+
+// Singleton with no state that implements
+// io.Reader and uses the default rand/v2
+// package to read bytes.
+type defaultRandReader struct{}
+
+// Read fills the provided byte slice `b` with random data using a
+// cryptographically secure random number generator.
+func (d defaultRandReader) Read(b []byte) (n int, err error) {
+	var num uint64
+	numByteIndex := 0
+
+	for i := range b {
+		if numByteIndex == 0 {
+			num = chacha8RandV2.Uint64()
+		}
+		b[i] = byte(num >> (numByteIndex * 8))
+		numByteIndex = (numByteIndex + 1) % 8
+	}
+
+	return len(b), nil
 }

--- a/uuid.go
+++ b/uuid.go
@@ -14,7 +14,7 @@ import (
 	// Uses math/rand/v2 for random number generation
 	// because it uses chacha8 as the default source,
 	// which is cryptographically secure and much faster
-	chacha8RandV2 "math/rand/v2"
+
 	"strings"
 	"sync"
 )
@@ -396,26 +396,4 @@ func (uuids UUIDs) Strings() []string {
 		uuidStrs[i] = uuid.String()
 	}
 	return uuidStrs
-}
-
-// Singleton with no state that implements
-// io.Reader and uses the default rand/v2
-// package to read bytes.
-type defaultRandReader struct{}
-
-// Read fills the provided byte slice `b` with random data using a
-// cryptographically secure random number generator.
-func (d defaultRandReader) Read(b []byte) (n int, err error) {
-	var num uint64
-	numByteIndex := 0
-
-	for i := range b {
-		if numByteIndex == 0 {
-			num = chacha8RandV2.Uint64()
-		}
-		b[i] = byte(num >> (numByteIndex * 8))
-		numByteIndex = (numByteIndex + 1) % 8
-	}
-
-	return len(b), nil
 }

--- a/version4.go
+++ b/version4.go
@@ -9,7 +9,7 @@ import "io"
 // New creates a new random UUID or panics.  New is equivalent to
 // the expression
 //
-//    uuid.Must(uuid.NewRandom())
+//	uuid.Must(uuid.NewRandom())
 func New() UUID {
 	return Must(NewRandom())
 }
@@ -17,7 +17,7 @@ func New() UUID {
 // NewString creates a new random UUID and returns it as a string or panics.
 // NewString is equivalent to the expression
 //
-//    uuid.New().String()
+//	uuid.New().String()
 func NewString() string {
 	return Must(NewRandom()).String()
 }
@@ -31,11 +31,11 @@ func NewString() string {
 //
 // A note about uniqueness derived from the UUID Wikipedia entry:
 //
-//  Randomly generated UUIDs have 122 random bits.  One's annual risk of being
-//  hit by a meteorite is estimated to be one chance in 17 billion, that
-//  means the probability is about 0.00000000006 (6 × 10−11),
-//  equivalent to the odds of creating a few tens of trillions of UUIDs in a
-//  year and having one duplicate.
+//	Randomly generated UUIDs have 122 random bits.  One's annual risk of being
+//	hit by a meteorite is estimated to be one chance in 17 billion, that
+//	means the probability is about 0.00000000006 (6 × 10−11),
+//	equivalent to the odds of creating a few tens of trillions of UUIDs in a
+//	year and having one duplicate.
 func NewRandom() (UUID, error) {
 	if !poolEnabled {
 		return NewRandomFromReader(rander)

--- a/version4.go
+++ b/version4.go
@@ -108,8 +108,8 @@ func (d defaultRandReader) Read(b []byte) (n int, err error) {
 func fastRandV4DefaultZeroAlloc() UUID {
 	var uuid UUID
 	hi, low := chacha8RandV2.Uint64(), chacha8RandV2.Uint64()
-	binary.LittleEndian.PutUint64(uuid[0:8], hi)
-	binary.LittleEndian.PutUint64(uuid[8:16], low)
+	binary.BigEndian.PutUint64(uuid[0:8], hi)
+	binary.BigEndian.PutUint64(uuid[8:16], low)
 
 	uuid[6] = (uuid[6] & 0x0f) | 0x40 // Version 4
 	uuid[8] = (uuid[8] & 0x3f) | 0x80 // Variant is 10

--- a/version4.go
+++ b/version4.go
@@ -4,7 +4,11 @@
 
 package uuid
 
-import "io"
+import (
+	"encoding/binary"
+	"io"
+	chacha8RandV2 "math/rand/v2"
+)
 
 // New creates a new random UUID or panics.  New is equivalent to
 // the expression
@@ -37,6 +41,10 @@ func NewString() string {
 //	equivalent to the odds of creating a few tens of trillions of UUIDs in a
 //	year and having one duplicate.
 func NewRandom() (UUID, error) {
+	if _, ok := rander.(defaultRandReader); ok {
+		return fastRandV4DefaultZeroAlloc(), nil
+	}
+
 	if !poolEnabled {
 		return NewRandomFromReader(rander)
 	}
@@ -73,4 +81,37 @@ func newRandomFromPool() (UUID, error) {
 	uuid[6] = (uuid[6] & 0x0f) | 0x40 // Version 4
 	uuid[8] = (uuid[8] & 0x3f) | 0x80 // Variant is 10
 	return uuid, nil
+}
+
+// Singleton with no state that implements
+// io.Reader and uses the default rand/v2
+// package to read bytes.
+type defaultRandReader struct{}
+
+// Read fills the provided byte slice `b` with random data using a
+// cryptographically secure random number generator.
+func (d defaultRandReader) Read(b []byte) (n int, err error) {
+	var num uint64
+	numByteIndex := 0
+
+	for i := range b {
+		if numByteIndex == 0 {
+			num = chacha8RandV2.Uint64()
+		}
+		b[i] = byte(num >> (numByteIndex * 8))
+		numByteIndex = (numByteIndex + 1) % 8
+	}
+
+	return len(b), nil
+}
+
+func fastRandV4DefaultZeroAlloc() UUID {
+	var uuid UUID
+	hi, low := chacha8RandV2.Uint64(), chacha8RandV2.Uint64()
+	binary.LittleEndian.PutUint64(uuid[0:8], hi)
+	binary.LittleEndian.PutUint64(uuid[8:16], low)
+
+	uuid[6] = (uuid[6] & 0x0f) | 0x40 // Version 4
+	uuid[8] = (uuid[8] & 0x3f) | 0x80 // Variant is 10
+	return uuid
 }


### PR DESCRIPTION
# Background:

In Go 1.22, the package `math/rand/v2` was introduced to the standard library: https://go.dev/blog/randv2 and https://go.dev/blog/chacha8rand . The new default `rand.Uint64()` now uses chacha8 and is cryptographically secure **and** thread safe. 

# Proposal

The UUID package can leverage the new default chacha8 secure random number generator to generate uuids way faster
and with zero allocations. The original implementation used a rand reader from the OS that made os api calls, but the new
standard can be used.

Benchmarks

Current (master)
```
goos: darwin
goarch: arm64
pkg: github.com/google/uuid
cpu: Apple M4
BenchmarkUUID_MarshalJSON-10       	12657015	        95.98 ns/op	      96 B/op	       2 allocs/op
BenchmarkUUID_UnmarshalJSON-10     	 3934029	       282.7 ns/op	     216 B/op	       4 allocs/op
BenchmarkParse-10                  	57056253	        21.30 ns/op	       0 B/op	       0 allocs/op
BenchmarkParseBytes-10             	54908913	        21.16 ns/op	       0 B/op	       0 allocs/op
BenchmarkParseBytesUnsafe-10       	56347286	        21.26 ns/op	       0 B/op	       0 allocs/op
BenchmarkParseBytesCopy-10         	39864680	        29.59 ns/op	      48 B/op	       1 allocs/op
BenchmarkNew-10                    	 6022090	       197.7 ns/op	      16 B/op	       1 allocs/op
BenchmarkUUID_String-10            	60293174	        19.68 ns/op	      48 B/op	       1 allocs/op
BenchmarkUUID_URN-10               	59736040	        20.45 ns/op	      48 B/op	       1 allocs/op
BenchmarkParseBadLength-10         	515349265	         2.329 ns/op	       0 B/op	       0 allocs/op
BenchmarkParseLen32Truncated-10    	196863027	         6.101 ns/op	       0 B/op	       0 allocs/op
BenchmarkParseLen36Corrupted-10    	56335933	        21.11 ns/op	       0 B/op	       0 allocs/op
BenchmarkUUID_New-10               	 2420439	       490.8 ns/op	      16 B/op	       1 allocs/op
BenchmarkUUID_NewPooled-10         	13393417	        87.63 ns/op	       0 B/op	       0 allocs/op
BenchmarkUUIDs_Strings-10          	22099090	        53.65 ns/op	     128 B/op	       3 allocs/op
BenchmarkNewV6WithTime-10          	 8837908	       135.3 ns/op	       0 B/op	       0 allocs/op
PASS
coverage: 31.6% of statements
```

Using rand v2 (ChaCha8)
```
goos: darwin
goarch: arm64
pkg: github.com/google/uuid
cpu: Apple M4
BenchmarkUUID_MarshalJSON-10       	12710013	        94.76 ns/op	      96 B/op	       2 allocs/op
BenchmarkUUID_UnmarshalJSON-10     	 4293664	       279.2 ns/op	     216 B/op	       4 allocs/op
BenchmarkParse-10                  	55501380	        21.93 ns/op	       0 B/op	       0 allocs/op
BenchmarkParseBytes-10             	56140239	        21.24 ns/op	       0 B/op	       0 allocs/op
BenchmarkParseBytesUnsafe-10       	55231239	        21.78 ns/op	       0 B/op	       0 allocs/op
BenchmarkParseBytesCopy-10         	38862096	        29.30 ns/op	      48 B/op	       1 allocs/op
BenchmarkNew-10                    	96230953	        12.45 ns/op	       0 B/op	       0 allocs/op
BenchmarkUUID_String-10            	62159926	        19.15 ns/op	      48 B/op	       1 allocs/op
BenchmarkUUID_URN-10               	59559139	        20.03 ns/op	      48 B/op	       1 allocs/op
BenchmarkParseBadLength-10         	517937542	         2.306 ns/op	       0 B/op	       0 allocs/op
BenchmarkParseLen32Truncated-10    	196604046	         6.102 ns/op	       0 B/op	       0 allocs/op
BenchmarkParseLen36Corrupted-10    	57532687	        20.68 ns/op	       0 B/op	       0 allocs/op
BenchmarkUUID_New-10               	631763211	         1.904 ns/op	       0 B/op	       0 allocs/op
BenchmarkUUID_NewPooled-10         	624191044	         1.944 ns/op	       0 B/op	       0 allocs/op
BenchmarkUUIDs_Strings-10          	21839292	        53.39 ns/op	     128 B/op	       3 allocs/op
BenchmarkNewV6WithTime-10          	 8800072	       148.1 ns/op	       0 B/op	       0 allocs/op
PASS
coverage: 29.4% of statements
ok  	github.com/google/uuid	22.469s
```

Notably, `New()` seems to be 10x faster while still 'cryptographically secure' due to the usage of the 
default methods in `math/rand/v2`, assuming the default `rand.Uint64()` is cryptographically secure. The proposal
also allows for **zero allocation** uuid v4 generation