### PR TITLE
Added Feature - Add MustParseBytes to support byte-slice UUID parsing

### DIFF
--- a/uuid.go
+++ b/uuid.go
@@ -52,7 +52,7 @@ var (
 	ErrInvalidBracketedFormat = errors.New("invalid bracketed UUID format")
 )
 
-type URNPrefixError struct { prefix string }
+type URNPrefixError struct{ prefix string }
 
 func (e URNPrefixError) Error() string {
 	return fmt.Sprintf("invalid urn prefix: %q", e.prefix)
@@ -199,6 +199,16 @@ func MustParse(s string) UUID {
 	return uuid
 }
 
+// MustParseBytes is like ParseBytes but panics if the byte slice cannot be parsed.
+// It simplifies safe initialization of global variables holding compiled UUIDs.
+func MustParseBytes(b []byte) UUID {
+	uuid, err := ParseBytes(b)
+	if err != nil {
+		panic(`uuid: ParseBytes(` + string(b) + `): ` + err.Error())
+	}
+	return uuid
+}
+
 // FromBytes creates a new UUID from a byte slice. Returns an error if the slice
 // does not have a length of 16. The bytes are copied from the slice.
 func FromBytes(b []byte) (uuid UUID, err error) {
@@ -215,10 +225,11 @@ func Must(uuid UUID, err error) UUID {
 }
 
 // Validate returns an error if s is not a properly formatted UUID in one of the following formats:
-//   xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-//   urn:uuid:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-//   xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-//   {xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}
+// xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+// urn:uuid:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+// xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+// {xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}
+//
 // It returns an error if the format is invalid, otherwise nil.
 func Validate(s string) error {
 	switch len(s) {


### PR DESCRIPTION
This pull request adds the MustParseBytes function to the uuid package.

While the package currently provides MustParse for strings, there was no equivalent helper for []byte inputs. This addition ensures API symmetry and simplifies the initialization of global variables or constants when the source UUID is represented as a byte slice (e.g., from a database driver or network buffer).

Changes
- Added MustParseBytes([]byte) UUID which wraps ParseBytes.
- Logic mirrors MustParse, including the panic behavior on failure to ensure it is safe for package-level variable initialization.
- Includes a descriptive panic message consistent with the existing MustParse implementation.

Example Usage
`var namespace = uuid.MustParseBytes([]byte("6ba7b810-9dad-11d1-80b4-00c04fd430c8"))`

Checklists
- [x] Code follows the existing style of the repository.
- [x] Function is documented with comments.
- [x] No breaking changes introduced.