### PR TITLE
Added feature: Added IsNil() Method for uuid. Also updated the Nil variable and Namespace constants documentation to reference RFC 9562 (the current standard obsoleting RFC 4122).

### DIFF
--- a/hash.go
+++ b/hash.go
@@ -16,7 +16,10 @@ var (
 	NameSpaceURL  = MustParse("6ba7b811-9dad-11d1-80b4-00c04fd430c8")
 	NameSpaceOID  = MustParse("6ba7b812-9dad-11d1-80b4-00c04fd430c8")
 	NameSpaceX500 = MustParse("6ba7b814-9dad-11d1-80b4-00c04fd430c8")
-	Nil           UUID // empty UUID, all zeros
+
+	// Nil is the "nil UUID" as defined in RFC 9562.
+	// It is composed of all zeros: 00000000-0000-0000-0000-000000000000.
+	Nil UUID
 
 	// The Max UUID is special form of UUID that is specified to have all 128 bits set to 1.
 	Max = UUID{

--- a/uuid.go
+++ b/uuid.go
@@ -315,6 +315,11 @@ func (uuid UUID) Version() Version {
 	return Version(uuid[6] >> 4)
 }
 
+// IsNil returns true if uuid is the Nil UUID.
+func (uuid UUID) IsNil() bool {
+	return uuid == Nil
+}
+
 func (v Version) String() string {
 	if v > 15 {
 		return fmt.Sprintf("BAD_VERSION_%d", v)


### PR DESCRIPTION
This PR adds a convenience method `IsNil()` to the `UUID` type.

While it is currently possible to check for a nil UUID by comparing against the package-level `Nil` variable, providing an `IsNil()` method is more idiomatic in Go and improves code readability when performing validation checks.

**Example:**
```
u, _ := uuid.Parse(input)
if u.IsNil() {
    // handle nil uuid
}
```

Also updated the Nil variable and Namespace constants documentation to reference RFC 9562 (the current standard obsoleting RFC 4122).
<img width="807" height="126" alt="image" src="https://github.com/user-attachments/assets/e8f0e16f-55d4-4a04-b798-2f56860a1c05" />
