### PR TITLE
fix: lock clock sequence in NewV6WithTime

### DIFF
--- a/version6.go
+++ b/version6.go
@@ -37,7 +37,12 @@ func NewV6() (UUID, error) {
 // are generating multiple UUIDs, it is recommended to increment the time.
 // If getTime fails to return the current NewV6WithTime returns Nil and an error.
 func NewV6WithTime(customTime *time.Time) (UUID, error) {
+	// getTime reads and mutates the shared clock sequence state, which is
+	// guarded by timeMu (see GetTime). Take the lock so concurrent generation
+	// stays race-free and keeps producing unique values.
+	timeMu.Lock()
 	now, seq, err := getTime(customTime)
+	timeMu.Unlock()
 	if err != nil {
 		return Nil, err
 	}

--- a/version6_test.go
+++ b/version6_test.go
@@ -1,6 +1,7 @@
 package uuid
 
 import (
+	"sync"
 	"testing"
 	"time"
 )
@@ -63,6 +64,49 @@ func TestNewV6FromTimeGeneratesUniqueUUIDs(t *testing.T) {
 	// Check we added all the UIDs
 	if len(ids) != runs {
 		t.Errorf("got %d UUIDs, want %d", len(ids), runs)
+	}
+}
+
+func TestNewV6WithTimeConcurrentUnique(t *testing.T) {
+	// NewV6WithTime must take the clock-sequence lock so concurrent generation
+	// for the same timestamp stays race-free and keeps producing unique values.
+	// For a fixed timestamp the UUID varies only by the clock sequence, so up
+	// to 16384 calls must all be unique. Run with -race to also surface the
+	// underlying data race directly.
+	fixed := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	const goroutines = 8
+	const perGoroutine = 2000 // 16000 total < 16384 clock-sequence values
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	seen := make(map[UUID]struct{}, goroutines*perGoroutine)
+	dups := 0
+
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				id, err := NewV6WithTime(&fixed)
+				if err != nil {
+					t.Errorf("NewV6WithTime returned unexpected error %v", err)
+					return
+				}
+				mu.Lock()
+				if _, ok := seen[id]; ok {
+					dups++
+				} else {
+					seen[id] = struct{}{}
+				}
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if dups != 0 {
+		t.Errorf("got %d duplicate V6 UUIDs from concurrent NewV6WithTime calls", dups)
 	}
 }
 


### PR DESCRIPTION
## Bug

`NewV6WithTime` generates duplicate UUIDs under concurrency, and has a data race on the shared clock-sequence state.

`getTime` reads and mutates the package globals `lasttime` and `clockSeq` (it bumps `clockSeq` whenever time hasn't advanced, which is what keeps same-timestamp UUIDs unique). That state is guarded by `timeMu`: `GetTime` — used by `NewV6()` and `NewUUID()` — takes the lock before calling `getTime`. `NewV6WithTime` (added in #172) is the only path that calls `getTime` directly, without the lock.

So concurrent `NewV6WithTime` callers read the same `clockSeq`/`lasttime` unsynchronized, producing identical UUIDs, and also race with `NewV6()`/`NewUUID()`, corrupting their uniqueness state.

## Fix

Take `timeMu` around the `getTime` call, matching `GetTime`:

```go
func NewV6WithTime(customTime *time.Time) (UUID, error) {
	timeMu.Lock()
	now, seq, err := getTime(customTime)
	timeMu.Unlock()
	...
```

## Testing

Added `TestNewV6WithTimeConcurrentUnique`: 8 goroutines generate 2000 V6 UUIDs each from the same fixed timestamp (16000 < 16384 clock-sequence values, so all must be unique). On the current code it fails deterministically (hundreds of duplicates) and `-race` reports the data race on `lasttime`/`clockSeq`; with the fix it passes cleanly. The full suite passes under `-race`, and `gofmt -s` is clean.
